### PR TITLE
Preventing stream from emitting header cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Encode csv to protobuf
 
-	npm install csv-to-protobuf
+	npm install csv-protobuf-stream
 
 ## Usage
 
 ``` js
-var csvProtobuf = require('csv-to-protobuf');
+var csvProtobuf = require('csv-protobuf-stream');
 var split = require('binary-split');
 var encoder = csvProtobuf();
 


### PR DESCRIPTION
(A little more tricky than the last PR)

Pushing the schema cells to the stream doesn't make much sense to me. The header itself isn't necessary payload. If required the header can be pushed to the stream by a `on("schema", ...)` listener. 
